### PR TITLE
Add-Dropcase-Dungeon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en-us">
 	<head>
+		<!-- <link rel="stylesheet" href="./stylesheet.css"> -->
 		<style type="text/css">
 			body style {
 				display: block;
@@ -80,6 +81,11 @@
 			<td><a href="#solbera">Solbera Imitation</a></td>
 			<td>Drop caps</td>
 		</tr>
+		<tr>
+			<td>(unknown)</td>
+			<td><a href="#dungeon-drop-case">Dungeon Drop Case (Ners)</a></td>
+			<td>Drop caps</td>
+		</tr>
 	</tbody>
 </table>
 
@@ -90,39 +96,37 @@
 	@font-face {
 		font-family: "Bookinsanity";
 		src: url("./Bookinsanity/Bookinsanity.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Bookinsanity Bold Italic";
+		font-family: "Bookinsanity";
 		src: url("./Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Bookinsanity Bold";
-		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold', serif; font-style: italic;">This text is in Bookinsanity Bold. The Bard was sure e could get through the gate. All e had to do is convincinly explain why e was being followed by a bright yellow, vocally angry Flumph.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Bookinsanity Italic";
-		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Italic', serif; font-style: italic;">This text is in Bookinsanity Italic. The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity";
+		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold;">This text is in Bookinsanity Bold. The Bard was sure he could get through the gate. All he had to do is convincinly explain why he was being followed by a bright yellow, vocally angry Flumph.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity";
+		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-style: italic;">This text is in Bookinsanity Italic. The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.</p>
 
 
 
@@ -131,39 +135,37 @@
 	@font-face {
 		font-family: "Zatanna Misdirection";
 		src: url("./Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection. Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Zatanna Misdirection Bold Italic";
+		font-family: "Zatanna Misdirection";
 		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic. The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Zatanna Misdirection Bold";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Zatanna Misdirection Italic";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Italic', serif; font-style: italic;">This text is in Zatanna Misdirection Italic. The Paladin had cracked. All they could think was the last words of eir opponent: "Only nothingness above."</p>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic. The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection";
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-weight: bold;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection";
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-style: italic;">This text is in Zatanna Misdirection Italic. The Paladin had cracked. All they could think was the last words of their opponent: "Only nothingness above."</p>
 
 
 
@@ -173,39 +175,37 @@
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
 		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed. The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Nodesto Caps Condensed Bold Italic";
+		font-family: "Nodesto Caps Condensed";
 		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic. At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Nodesto Caps Condensed Bold";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold', serif; font-style: italic;">This text is in Nodesto Caps Condensed Bold. The Warlock's patron had brought em to a strange and desolate island, but eir task here was obvious. The castle on the central peak must be purged.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Nodesto Caps Condensed Italic";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Italic', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic. The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.</p>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic. At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed";
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-weight: bold;">This text is in Nodesto Caps Condensed Bold. The Warlock's patron had brought em to a strange and desolate island, but eir task here was obvious. The castle on the central peak must be purged.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed";
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic. The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.</p>
 
 
 
@@ -214,7 +214,7 @@
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
 		src: url("./Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
-		font-weight: normal;
+		font-feature-settings: "smcp" on;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Mr Eaves Small Caps', serif;">This text is in Mr Eaves Small Caps. In a hole in the ground there lived a Halfling, for he had not yet heard the call of adventure. That would come next week, when the tavern burned down.</p>
@@ -226,40 +226,37 @@
 	@font-face {
 		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans. The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Bold Italic";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Bold";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Bold.otf") format("opentype");
 		font-weight: bold;
-		font-style: normal;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; ">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-weight: bold;">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Italic";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Italic', serif; font-style: italic;">This text is in Scaly Sans Italic. If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-style: italic;">This text is in Scaly Sans Italic. If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.</p>
 
 
 
@@ -268,39 +265,37 @@
 	@font-face {
 		font-family: "Scaly Sans Caps";
 		src: url("./Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps. This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Caps Bold Italic";
+		font-family: "Scaly Sans Caps";
 		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic. The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Scaly Sans Caps Bold";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Scaly Sans Caps Italic";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Italic', serif; font-style: italic;">This text is in Scaly Sans Caps Italic. The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic. The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps";
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-weight: bold;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps";
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-style: italic;">This text is in Scaly Sans Caps Italic. The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.</p>
 
 
 
@@ -309,10 +304,17 @@
 	@font-face {
 		font-family: "Solbera Imitation";
 		src: url("./Solbera Imitation/Solbera Imitation.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation. If you can read this text, talk to the priest of the smallest temple in the city.</p>
+
+<style id="dungeon-drop-case" type="text/css">
+	@font-face {
+		font-family: "Dungeon Drop Case";
+		src: url("./Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Dungeon Drop Case', serif;">This text is in Dungeon Drop Case. The wizard Eigengrau shook her head. The text was totally illegible, and she found that she couldn't decipher it, despite her skill.</p>
 
 <footer>
 	<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en-us">
 	<head>
-		<!-- <link rel="stylesheet" href="./stylesheet.css"> -->
+		<!-- <link rel="stylesheet" href="stylesheet.css"> -->
 		<style type="text/css">
 			body style {
 				display: block;
@@ -95,25 +95,38 @@
 <style id="bookinsanity" type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity.otf") format("opentype");
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey. The jewels in his pouch clinked gently.</p>
+
 
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into the bar, sat down at a table, and ordered the largest mug of the foulest brew that the innkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
 
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -122,7 +135,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -134,7 +151,10 @@
 <style id="zatanna" type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection. Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.</p>
@@ -142,7 +162,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -152,7 +175,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -161,7 +187,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -174,7 +203,10 @@
 <style id="nodesto" type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed. The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.</p>
@@ -182,7 +214,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -192,7 +227,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -201,7 +239,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -213,7 +254,10 @@
 <style id="eaves"type="text/css">
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
-		src: url("./Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+		src: 
+			local("Mr Eaves Small Caps"),
+			url("./Mr Eaves/Mr Eaves Small Caps.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Mr%20Eaves/Mr%20Eaves%20Small%20Caps.otf") format("opentype");
 		font-feature-settings: "smcp" on;
 	}
 </style>
@@ -225,7 +269,11 @@
 <style id="scaly" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans. The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.</p>
@@ -233,7 +281,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -243,7 +295,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -252,7 +308,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -264,7 +324,10 @@
 <style id="scalycaps" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps. This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.</p>
@@ -272,7 +335,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -282,7 +348,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -291,7 +360,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -303,7 +375,10 @@
 <style id="solbera" type="text/css">
 	@font-face {
 		font-family: "Solbera Imitation";
-		src: url("./Solbera Imitation/Solbera Imitation.otf") format("opentype");
+		src: 
+			local("Solbera Imitation"),
+			url("./Solbera Imitation/Solbera Imitation.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Solbera%20Imitation/Solbera%20Imitation.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation. If you can read this text, talk to the priest of the smallest temple in the city.</p>
@@ -311,7 +386,12 @@
 <style id="dungeon-drop-case" type="text/css">
 	@font-face {
 		font-family: "Dungeon Drop Case";
-		src: url("./Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+		src: 
+			local("Dungeon Drop Case"),
+			url("./Dungeon Drop Case/Dungeon Drop Case.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Dungeon%20Drop%20Case/Dungeon%20Drop%20Case.otf") format("opentype");
+			
+		
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Dungeon Drop Case', serif;">This text is in Dungeon Drop Case. The wizard Eigengrau shook her head. The text was totally illegible, and she found that she couldn't decipher it, despite her skill.</p>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,130 @@
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Mr Eaves Small Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Solbera Imitation";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Solbera Imitation/Solbera Imitation.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Dungeon Drop Case";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+    font-weight: normal;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,130 +1,189 @@
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity.otf") format("opentype");
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection.otf") format("opentype");
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed.otf") format("opentype");
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Mr Eaves Small Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Mr Eaves Small Caps"),
+        url('./Mr Eaves/Mr Eaves Small Caps.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Mr%20Eaves/Mr%20Eaves%20Small%20Caps.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Solbera Imitation";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Solbera Imitation/Solbera Imitation.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Solbera Imitation"),
+        url('./Solbera Imitation/Solbera Imitation.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Solbera%20Imitation/Solbera%20Imitation.otf") format("opentype");
 }
 @font-face {
     font-family: "Dungeon Drop Case";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Dungeon Drop Case"),
+        url('/Dungeon Drop Case/Dungeon Drop Case.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Dungeon%20Drop%20Case/Dungeon%20Drop%20Case.otf") format("opentype");
 }


### PR DESCRIPTION
I have added the Drop Case Dungeon to the .html file. I would suggest that you enable GitHub Pages so the `index.html` file is accessible online.

I have also added local sources for fonts, in case the user has already downloaded them and installed them to their computer. 

I have removed the font-weight: normal and other unnecessary css from the html.

For compatibility, I would suggest that the filenames be changed to all lowercase, using kebab case to avoid any unexpected IE incompatibilities, as well as make it easier to read.



I have added an example CSS page. This does not include things like font-display, so those are left to the user.