### PR TITLE
Update the preview to use Svelte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 #*
 *.swp
 !.gitignore
+/node_modules/
+/public/build/
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en-us">
 	<head>
+		<!-- <link rel="stylesheet" href="./stylesheet.css"> -->
 		<style type="text/css">
 			body style {
 				display: block;
@@ -80,6 +81,11 @@
 			<td><a href="#solbera">Solbera Imitation</a></td>
 			<td>Drop caps</td>
 		</tr>
+		<tr>
+			<td>(unknown)</td>
+			<td><a href="#dungeon-drop-case">Dungeon Drop Case (Ners)</a></td>
+			<td>Drop caps</td>
+		</tr>
 	</tbody>
 </table>
 
@@ -90,39 +96,37 @@
 	@font-face {
 		font-family: "Bookinsanity";
 		src: url("./Bookinsanity/Bookinsanity.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Bookinsanity Bold Italic";
+		font-family: "Bookinsanity";
 		src: url("./Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Bookinsanity Bold";
-		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Bold', serif; font-style: italic;">This text is in Bookinsanity Bold. The Bard was sure e could get through the gate. All e had to do is convincinly explain why e was being followed by a bright yellow, vocally angry Flumph.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Bookinsanity Italic";
-		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity Italic', serif; font-style: italic;">This text is in Bookinsanity Italic. The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity";
+		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold;">This text is in Bookinsanity Bold. The Bard was sure he could get through the gate. All he had to do is convincinly explain why he was being followed by a bright yellow, vocally angry Flumph.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Bookinsanity";
+		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-style: italic;">This text is in Bookinsanity Italic. The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.</p>
 
 
 
@@ -131,39 +135,37 @@
 	@font-face {
 		font-family: "Zatanna Misdirection";
 		src: url("./Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection. Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Zatanna Misdirection Bold Italic";
+		font-family: "Zatanna Misdirection";
 		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic. The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Zatanna Misdirection Bold";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Bold', serif;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Zatanna Misdirection Italic";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection Italic', serif; font-style: italic;">This text is in Zatanna Misdirection Italic. The Paladin had cracked. All they could think was the last words of eir opponent: "Only nothingness above."</p>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-weight: bold; font-style: italic;">This text is in Zatanna Misdirection Bold Italic. The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection";
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-weight: bold;">This text is in Zatanna Misdirection Bold. High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Zatanna Misdirection";
+		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif; font-style: italic;">This text is in Zatanna Misdirection Italic. The Paladin had cracked. All they could think was the last words of their opponent: "Only nothingness above."</p>
 
 
 
@@ -173,39 +175,37 @@
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
 		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed. The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Nodesto Caps Condensed Bold Italic";
+		font-family: "Nodesto Caps Condensed";
 		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic. At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Nodesto Caps Condensed Bold";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Bold', serif; font-style: italic;">This text is in Nodesto Caps Condensed Bold. The Warlock's patron had brought em to a strange and desolate island, but eir task here was obvious. The castle on the central peak must be purged.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Nodesto Caps Condensed Italic";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed Italic', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic. The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.</p>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-weight: bold; font-style: italic;">This text is in Nodesto Caps Condensed Bold Italic. At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed";
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-weight: bold;">This text is in Nodesto Caps Condensed Bold. The Warlock's patron had brought em to a strange and desolate island, but eir task here was obvious. The castle on the central peak must be purged.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Nodesto Caps Condensed";
+		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif; font-style: italic;">This text is in Nodesto Caps Condensed Italic. The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.</p>
 
 
 
@@ -214,7 +214,7 @@
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
 		src: url("./Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
-		font-weight: normal;
+		font-feature-settings: "smcp" on;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Mr Eaves Small Caps', serif;">This text is in Mr Eaves Small Caps. In a hole in the ground there lived a Halfling, for he had not yet heard the call of adventure. That would come next week, when the tavern burned down.</p>
@@ -226,40 +226,37 @@
 	@font-face {
 		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans. The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Bold Italic";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Bold Italic. It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Bold";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Bold.otf") format("opentype");
 		font-weight: bold;
-		font-style: normal;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Bold', serif; ">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-weight: bold;">This text is in Scaly Sans Bold. Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Italic";
+		font-family: "Scaly Sans";
 		src: url("./Scaly Sans/Scaly Sans Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Italic', serif; font-style: italic;">This text is in Scaly Sans Italic. If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans', serif; font-style: italic;">This text is in Scaly Sans Italic. If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.</p>
 
 
 
@@ -268,39 +265,37 @@
 	@font-face {
 		font-family: "Scaly Sans Caps";
 		src: url("./Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps. This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.</p>
 
 <style type="text/css">
 	@font-face {
-		font-family: "Scaly Sans Caps Bold Italic";
+		font-family: "Scaly Sans Caps";
 		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
 		font-weight: bold;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold Italic', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic. The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Scaly Sans Caps Bold";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
-		font-weight: bold;
-		font-style: normal;
-	}
-</style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Bold', serif;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
-
-<style type="text/css">
-	@font-face {
-		font-family: "Scaly Sans Caps Italic";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
-		font-weight: normal;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps Italic', serif; font-style: italic;">This text is in Scaly Sans Caps Italic. The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.</p>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-weight: bold; font-style: italic;">This text is in Scaly Sans Caps Bold Italic. The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps";
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		font-weight: bold;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-weight: bold;">This text is in Scaly Sans Caps Bold. The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.</p>
+
+<style type="text/css">
+	@font-face {
+		font-family: "Scaly Sans Caps";
+		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		font-style: italic;
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif; font-style: italic;">This text is in Scaly Sans Caps Italic. The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.</p>
 
 
 
@@ -309,10 +304,17 @@
 	@font-face {
 		font-family: "Solbera Imitation";
 		src: url("./Solbera Imitation/Solbera Imitation.otf") format("opentype");
-		font-weight: normal;
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation. If you can read this text, talk to the priest of the smallest temple in the city.</p>
+
+<style id="dungeon-drop-case" type="text/css">
+	@font-face {
+		font-family: "Dungeon Drop Case";
+		src: url("./Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+	}
+</style>
+<p contenteditable class="demo" style="font-family: 'Dungeon Drop Case', serif;">This text is in Dungeon Drop Case. The wizard Eigengrau shook her head. The text was totally illegible, and she found that she couldn't decipher it, despite her skill.</p>
 
 <footer>
 	<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html lang="en-us">
 	<head>
-		<!-- <link rel="stylesheet" href="./stylesheet.css"> -->
+		<!-- <link rel="stylesheet" href="stylesheet.css"> -->
 		<style type="text/css">
 			body style {
 				display: block;
@@ -95,25 +95,38 @@
 <style id="bookinsanity" type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity.otf") format("opentype");
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif;">This text is in Bookinsanity. The rains fell softly on the forest, dampening the Ranger as he waited for his prey. The jewels in his pouch clinked gently.</p>
+
 
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
 </style>
-<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into a bar, sat down at a table, and ordered the largest mug of the foulest brew that the inkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
+<p contenteditable class="demo" style="font-family: 'Bookinsanity', serif; font-weight: bold; font-style: italic;">This text is in Bookinsanity Bold Italic. The Barbarian waltzed into the bar, sat down at a table, and ordered the largest mug of the foulest brew that the innkeep had to sell. She needed to wash the taste of Undead out of her teeth.</p>
 
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -122,7 +135,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Bookinsanity";
-		src: url("./Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+		src: 
+			local("Bookinsanity Remake"),
+			local("Bookinsanity"),
+			url("./Bookinsanity/Bookinsanity Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -134,7 +151,10 @@
 <style id="zatanna" type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Zatanna Misdirection', serif;">This text is in Zatanna Misdirection. Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.</p>
@@ -142,7 +162,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -152,7 +175,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -161,7 +187,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Zatanna Misdirection";
-		src: url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+		src: 
+			local("Zatanna Misdirection"),
+			url("./Zatanna Misdirection/Zatanna Misdirection Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -174,7 +203,10 @@
 <style id="nodesto" type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Nodesto Caps Condensed', serif;">This text is in Nodesto Caps Condensed. The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.</p>
@@ -182,7 +214,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -192,7 +227,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -201,7 +239,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Nodesto Caps Condensed";
-		src: url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+		src: 
+			local("Nodesto Caps Condensed"),
+			url("./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -213,7 +254,10 @@
 <style id="eaves"type="text/css">
 	@font-face {
 		font-family: "Mr Eaves Small Caps";
-		src: url("./Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+		src: 
+			local("Mr Eaves Small Caps"),
+			url("./Mr Eaves/Mr Eaves Small Caps.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Mr%20Eaves/Mr%20Eaves%20Small%20Caps.otf") format("opentype");
 		font-feature-settings: "smcp" on;
 	}
 </style>
@@ -225,7 +269,11 @@
 <style id="scaly" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans', serif;">This text is in Scaly Sans. The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.</p>
@@ -233,7 +281,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -243,7 +295,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -252,7 +308,11 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans";
-		src: url("./Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Remake"),
+			local("Scaly Sans"),
+			url("./Scaly Sans/Scaly Sans Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -264,7 +324,10 @@
 <style id="scalycaps" type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Scaly Sans Caps', serif;">This text is in Scaly Sans Caps. This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.</p>
@@ -272,7 +335,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold%20Italic.otf") format("opentype");
 		font-weight: bold;
 		font-style: italic;
 	}
@@ -282,7 +348,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Bold.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold.otf") format("opentype");
 		font-weight: bold;
 	}
 </style>
@@ -291,7 +360,10 @@
 <style type="text/css">
 	@font-face {
 		font-family: "Scaly Sans Caps";
-		src: url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+		src: 
+			local("Scaly Sans Caps"),
+			url("./Scaly Sans Caps/Scaly Sans Caps Italic.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Italic.otf") format("opentype");
 		font-style: italic;
 	}
 </style>
@@ -303,7 +375,10 @@
 <style id="solbera" type="text/css">
 	@font-face {
 		font-family: "Solbera Imitation";
-		src: url("./Solbera Imitation/Solbera Imitation.otf") format("opentype");
+		src: 
+			local("Solbera Imitation"),
+			url("./Solbera Imitation/Solbera Imitation.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Solbera%20Imitation/Solbera%20Imitation.otf") format("opentype");
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Solbera Imitation', serif;">This text is in Solbera Imitation. If you can read this text, talk to the priest of the smallest temple in the city.</p>
@@ -311,7 +386,12 @@
 <style id="dungeon-drop-case" type="text/css">
 	@font-face {
 		font-family: "Dungeon Drop Case";
-		src: url("./Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+		src: 
+			local("Dungeon Drop Case"),
+			url("./Dungeon Drop Case/Dungeon Drop Case.otf"),
+			url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Dungeon%20Drop%20Case/Dungeon%20Drop%20Case.otf") format("opentype");
+			
+		
 	}
 </style>
 <p contenteditable class="demo" style="font-family: 'Dungeon Drop Case', serif;">This text is in Dungeon Drop Case. The wizard Eigengrau shook her head. The text was totally illegible, and she found that she couldn't decipher it, despite her skill.</p>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "solbera-dnd-fonts",
+  "version": "1.0.0",
+  "author": {
+    "name": "Solbera",
+    "email": "https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/"
+  },
+  "contributors": [
+    {
+      "name": "Ryrok",
+      "email": "https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/"
+    },
+    {
+      "name": "Ners",
+      "email": "https://www.reddit.com/r/UnearthedArcana/comments/71wzc2/new_indesign_template_and_open_source_fonts/"
+    }
+  ],
+  "maintainers": [
+    {
+      "name": "jonathonf",
+      "url": "https://github.com/jonathonf/"
+    },
+    {
+      "name": "ryceg",
+      "url": "https://github.com/ryceg"
+    }
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "start": "sirv public --no-clear",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0",
+    "rollup": "^2.3.4",
+    "rollup-plugin-css-only": "^3.1.0",
+    "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-svelte": "^7.0.0",
+    "rollup-plugin-terser": "^7.0.0",
+    "svelte": "^3.0.0",
+    "svelte-check": "^2.0.0",
+    "svelte-preprocess": "^4.0.0",
+    "@rollup/plugin-typescript": "^8.0.0",
+    "typescript": "^4.0.0",
+    "tslib": "^2.0.0",
+    "@tsconfig/svelte": "^2.0.0"
+  },
+  "dependencies": {
+    "sirv-cli": "^2.0.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,968 @@
+lockfileVersion: 5.3
+
+specifiers:
+  '@rollup/plugin-commonjs': ^17.0.0
+  '@rollup/plugin-node-resolve': ^11.0.0
+  '@rollup/plugin-typescript': ^8.0.0
+  '@tsconfig/svelte': ^2.0.0
+  rollup: ^2.3.4
+  rollup-plugin-css-only: ^3.1.0
+  rollup-plugin-livereload: ^2.0.0
+  rollup-plugin-svelte: ^7.0.0
+  rollup-plugin-terser: ^7.0.0
+  sirv-cli: ^2.0.0
+  svelte: ^3.0.0
+  svelte-check: ^2.0.0
+  svelte-preprocess: ^4.0.0
+  tslib: ^2.0.0
+  typescript: ^4.0.0
+
+dependencies:
+  sirv-cli: 2.0.2
+
+devDependencies:
+  '@rollup/plugin-commonjs': 17.1.0_rollup@2.70.1
+  '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
+  '@rollup/plugin-typescript': 8.3.1_8fb0118e9d69f3600cbb8f144f7d456c
+  '@tsconfig/svelte': 2.0.1
+  rollup: 2.70.1
+  rollup-plugin-css-only: 3.1.0_rollup@2.70.1
+  rollup-plugin-livereload: 2.0.5
+  rollup-plugin-svelte: 7.1.0_rollup@2.70.1+svelte@3.46.4
+  rollup-plugin-terser: 7.0.2_rollup@2.70.1
+  svelte: 3.46.4
+  svelte-check: 2.4.6_svelte@3.46.4
+  svelte-preprocess: 4.10.4_svelte@3.46.4+typescript@4.6.3
+  tslib: 2.3.1
+  typescript: 4.6.3
+
+packages:
+
+  /@babel/code-frame/7.16.7:
+    resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.16.10
+    dev: true
+
+  /@babel/helper-validator-identifier/7.16.7:
+    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/highlight/7.16.10:
+    resolution: {integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.16.7
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
+  /@nodelib/fs.scandir/2.1.5:
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+    dev: true
+
+  /@nodelib/fs.stat/2.0.5:
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /@nodelib/fs.walk/1.2.8:
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.13.0
+    dev: true
+
+  /@polka/url/1.0.0-next.21:
+    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: false
+
+  /@rollup/plugin-commonjs/17.1.0_rollup@2.70.1:
+    resolution: {integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^2.30.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.2.0
+      is-reference: 1.2.1
+      magic-string: 0.25.9
+      resolve: 1.22.0
+      rollup: 2.70.1
+    dev: true
+
+  /@rollup/plugin-node-resolve/11.2.1_rollup@2.70.1:
+    resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.2.0
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.22.0
+      rollup: 2.70.1
+    dev: true
+
+  /@rollup/plugin-typescript/8.3.1_8fb0118e9d69f3600cbb8f144f7d456c:
+    resolution: {integrity: sha512-84rExe3ICUBXzqNX48WZV2Jp3OddjTMX97O2Py6D1KJaGSwWp0mDHXj+bCGNJqWHIEKDIT2U0sDjhP4czKi6cA==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.70.1
+      resolve: 1.22.0
+      rollup: 2.70.1
+      tslib: 2.3.1
+      typescript: 4.6.3
+    dev: true
+
+  /@rollup/pluginutils/3.1.0_rollup@2.70.1:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 2.70.1
+    dev: true
+
+  /@rollup/pluginutils/4.2.0:
+    resolution: {integrity: sha512-2WUyJNRkyH5p487pGnn4tWAsxhEFKN/pT8CMgHshd5H+IXkOnKvKZwsz5ZWz+YCXkleZRAU5kwbfgF8CPfDRqA==}
+    engines: {node: '>= 8.0.0'}
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /@tsconfig/svelte/2.0.1:
+    resolution: {integrity: sha512-aqkICXbM1oX5FfgZd2qSSAGdyo/NRxjWCamxoyi3T8iVQnzGge19HhDYzZ6NrVOW7bhcWNSq9XexWFtMzbB24A==}
+    dev: true
+
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: true
+
+  /@types/estree/0.0.51:
+    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
+    dev: true
+
+  /@types/node/17.0.23:
+    resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
+    dev: true
+
+  /@types/pug/2.0.6:
+    resolution: {integrity: sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==}
+    dev: true
+
+  /@types/resolve/1.17.1:
+    resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
+    dependencies:
+      '@types/node': 17.0.23
+    dev: true
+
+  /@types/sass/1.43.1:
+    resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
+    dependencies:
+      '@types/node': 17.0.23
+    dev: true
+
+  /acorn/8.7.0:
+    resolution: {integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /ansi-styles/3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+    dependencies:
+      color-convert: 1.9.3
+    dev: true
+
+  /anymatch/3.1.2:
+    resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
+    engines: {node: '>= 8'}
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+    dev: true
+
+  /balanced-match/1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /binary-extensions/2.2.0:
+    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /brace-expansion/1.1.11:
+    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+    dev: true
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
+    dev: true
+
+  /buffer-crc32/0.2.13:
+    resolution: {integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=}
+    dev: true
+
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /builtin-modules/3.2.0:
+    resolution: {integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /callsites/3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /chalk/2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+    dev: true
+
+  /chokidar/3.5.3:
+    resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /color-convert/1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    dependencies:
+      color-name: 1.1.3
+    dev: true
+
+  /color-name/1.1.3:
+    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
+    dev: true
+
+  /commander/2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
+
+  /commondir/1.0.1:
+    resolution: {integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=}
+    dev: true
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    dev: true
+
+  /console-clear/1.1.1:
+    resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /detect-indent/6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /es6-promise/3.3.1:
+    resolution: {integrity: sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=}
+    dev: true
+
+  /escape-string-regexp/1.0.5:
+    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
+    engines: {node: '>=0.8.0'}
+    dev: true
+
+  /estree-walker/0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+    dev: true
+
+  /estree-walker/1.0.1:
+    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
+    dev: true
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /fast-glob/3.2.11:
+    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fastq/1.13.0:
+    resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
+    dependencies:
+      reusify: 1.0.4
+    dev: true
+
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
+  /fs.realpath/1.0.0:
+    resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /get-port/3.2.0:
+    resolution: {integrity: sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=}
+    engines: {node: '>=4'}
+    dev: false
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
+    dev: true
+
+  /glob/7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: true
+
+  /graceful-fs/4.2.9:
+    resolution: {integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==}
+    dev: true
+
+  /has-flag/3.0.0:
+    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=}
+    engines: {node: '>=4'}
+    dev: true
+
+  /has-flag/4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /import-fresh/3.3.0:
+    resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
+    engines: {node: '>=6'}
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+    dev: true
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: true
+
+  /inherits/2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /is-binary-path/2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+    dependencies:
+      binary-extensions: 2.2.0
+    dev: true
+
+  /is-core-module/2.8.1:
+    resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-extglob/2.1.1:
+    resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-glob/4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extglob: 2.1.1
+    dev: true
+
+  /is-module/1.0.0:
+    resolution: {integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=}
+    dev: true
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+    dev: true
+
+  /is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 0.0.51
+    dev: true
+
+  /jest-worker/26.6.2:
+    resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 17.0.23
+      merge-stream: 2.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /js-tokens/4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /kleur/4.1.4:
+    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /livereload-js/3.3.3:
+    resolution: {integrity: sha512-a7Jipme3XIBIryJluWP5LQrEAvhobDPyScBe+q+MYwxBiMT2Ck7msy4tAdF8TAa33FMdJqX4guP81Yhiu6BkmQ==}
+    dev: true
+
+  /livereload/0.9.3:
+    resolution: {integrity: sha512-q7Z71n3i4X0R9xthAryBdNGVGAO2R5X+/xXpmKeuPMrteg+W2U8VusTKV3YiJbXZwKsOlFlHe+go6uSNjfxrZw==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      livereload-js: 3.3.3
+      opts: 2.0.2
+      ws: 7.5.7
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /local-access/1.1.0:
+    resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /magic-string/0.25.9:
+    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
+  /merge-stream/2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    dev: true
+
+  /merge2/1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
+    dev: true
+
+  /min-indent/1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+    dependencies:
+      brace-expansion: 1.1.11
+    dev: true
+
+  /minimist/1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
+
+  /mkdirp/0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.6
+    dev: true
+
+  /mri/1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  /mrmime/1.0.0:
+    resolution: {integrity: sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==}
+    engines: {node: '>=10'}
+    dev: false
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /once/1.4.0:
+    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    dependencies:
+      wrappy: 1.0.2
+    dev: true
+
+  /opts/2.0.2:
+    resolution: {integrity: sha512-k41FwbcLnlgnFh69f4qdUfvDQ+5vaSDnVPFI/y5XuhKRq97EnVVneO9F1ESVCdiVu4fCS2L8usX3mU331hB7pg==}
+    dev: true
+
+  /parent-module/1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+    dependencies:
+      callsites: 3.1.0
+    dev: true
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /picocolors/1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /queue-microtask/1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /randombytes/2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /readdirp/3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
+    dev: true
+
+  /require-relative/0.8.7:
+    resolution: {integrity: sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=}
+    dev: true
+
+  /resolve-from/4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /resolve/1.22.0:
+    resolution: {integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.8.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /reusify/1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
+
+  /rimraf/2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    hasBin: true
+    dependencies:
+      glob: 7.2.0
+    dev: true
+
+  /rollup-plugin-css-only/3.1.0_rollup@2.70.1:
+    resolution: {integrity: sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==}
+    engines: {node: '>=10.12.0'}
+    peerDependencies:
+      rollup: 1 || 2
+    dependencies:
+      '@rollup/pluginutils': 4.2.0
+      rollup: 2.70.1
+    dev: true
+
+  /rollup-plugin-livereload/2.0.5:
+    resolution: {integrity: sha512-vqQZ/UQowTW7VoiKEM5ouNW90wE5/GZLfdWuR0ELxyKOJUIaj+uismPZZaICU4DnWPVjnpCDDxEqwU7pcKY/PA==}
+    engines: {node: '>=8.3'}
+    dependencies:
+      livereload: 0.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    dev: true
+
+  /rollup-plugin-svelte/7.1.0_rollup@2.70.1+svelte@3.46.4:
+    resolution: {integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      rollup: '>=2.0.0'
+      svelte: '>=3.5.0'
+    dependencies:
+      require-relative: 0.8.7
+      rollup: 2.70.1
+      rollup-pluginutils: 2.8.2
+      svelte: 3.46.4
+    dev: true
+
+  /rollup-plugin-terser/7.0.2_rollup@2.70.1:
+    resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
+    peerDependencies:
+      rollup: ^2.0.0
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      jest-worker: 26.6.2
+      rollup: 2.70.1
+      serialize-javascript: 4.0.0
+      terser: 5.12.1
+    dev: true
+
+  /rollup-pluginutils/2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+    dependencies:
+      estree-walker: 0.6.1
+    dev: true
+
+  /rollup/2.70.1:
+    resolution: {integrity: sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /run-parallel/1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    dependencies:
+      queue-microtask: 1.2.3
+    dev: true
+
+  /sade/1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /sander/0.5.1:
+    resolution: {integrity: sha1-dB4kXiMfB8r7b98PEzrfohalAq0=}
+    dependencies:
+      es6-promise: 3.3.1
+      graceful-fs: 4.2.9
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
+    dev: true
+
+  /semiver/1.1.0:
+    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /serialize-javascript/4.0.0:
+    resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
+  /sirv-cli/2.0.2:
+    resolution: {integrity: sha512-OtSJDwxsF1NWHc7ps3Sa0s+dPtP15iQNJzfKVz+MxkEo3z72mCD+yu30ct79rPr0CaV1HXSOBp+MIY5uIhHZ1A==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    dependencies:
+      console-clear: 1.1.1
+      get-port: 3.2.0
+      kleur: 4.1.4
+      local-access: 1.1.0
+      sade: 1.8.1
+      semiver: 1.1.0
+      sirv: 2.0.2
+      tinydate: 1.3.0
+    dev: false
+
+  /sirv/2.0.2:
+    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mrmime: 1.0.0
+      totalist: 3.0.0
+    dev: false
+
+  /sorcery/0.10.0:
+    resolution: {integrity: sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=}
+    hasBin: true
+    dependencies:
+      buffer-crc32: 0.2.13
+      minimist: 1.2.6
+      sander: 0.5.1
+      sourcemap-codec: 1.4.8
+    dev: true
+
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map/0.7.3:
+    resolution: {integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
+
+  /strip-indent/3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      min-indent: 1.0.1
+    dev: true
+
+  /supports-color/5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+    dependencies:
+      has-flag: 3.0.0
+    dev: true
+
+  /supports-color/7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /svelte-check/2.4.6_svelte@3.46.4:
+    resolution: {integrity: sha512-luzdly7RJhyXucQe8ID/7CqDgXdMrPYXmyZBjCbp+cixzTopZotuWevrB5hWDOnOU19m2cyetigIIa7WDHnCmQ==}
+    hasBin: true
+    peerDependencies:
+      svelte: ^3.24.0
+    dependencies:
+      chokidar: 3.5.3
+      fast-glob: 3.2.11
+      import-fresh: 3.3.0
+      minimist: 1.2.6
+      picocolors: 1.0.0
+      sade: 1.8.1
+      source-map: 0.7.3
+      svelte: 3.46.4
+      svelte-preprocess: 4.10.4_svelte@3.46.4+typescript@4.6.3
+      typescript: 4.6.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - node-sass
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+    dev: true
+
+  /svelte-preprocess/4.10.4_svelte@3.46.4+typescript@4.6.3:
+    resolution: {integrity: sha512-fuwol0N4UoHsNQolLFbMqWivqcJ9N0vfWO9IuPAiX/5okfoGXURyJ6nECbuEIv0nU3M8Xe2I1ONNje2buk7l6A==}
+    engines: {node: '>= 9.11.2'}
+    requiresBuild: true
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3 || ^4.0.0
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.55.0
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@types/pug': 2.0.6
+      '@types/sass': 1.43.1
+      detect-indent: 6.1.0
+      magic-string: 0.25.9
+      sorcery: 0.10.0
+      strip-indent: 3.0.0
+      svelte: 3.46.4
+      typescript: 4.6.3
+    dev: true
+
+  /svelte/3.46.4:
+    resolution: {integrity: sha512-qKJzw6DpA33CIa+C/rGp4AUdSfii0DOTCzj/2YpSKKayw5WGSS624Et9L1nU1k2OVRS9vaENQXp2CVZNU+xvIg==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /terser/5.12.1:
+    resolution: {integrity: sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      acorn: 8.7.0
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+    dev: true
+
+  /tinydate/1.3.0:
+    resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
+
+  /totalist/3.0.0:
+    resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /tslib/2.3.1:
+    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
+    dev: true
+
+  /typescript/4.6.3:
+    resolution: {integrity: sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    dev: true
+
+  /ws/7.5.7:
+    resolution: {integrity: sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: true

--- a/public/global.css
+++ b/public/global.css
@@ -1,0 +1,73 @@
+html, body {
+	position: relative;
+	scroll-behavior: smooth;
+	width: 100%;
+	height: 100%;
+}
+
+body {
+	color: #333;
+	margin: 0;
+	padding: 8px;
+	padding-left: 1em;
+	padding-right: 1em;
+	box-sizing: border-box;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #333;
+		color: #eee;
+	}
+}
+
+a {
+	color: rgb(0,100,200);
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+a:visited {
+	color: rgb(0,80,160);
+}
+
+label {
+	display: block;
+}
+
+input, button, select, textarea {
+	font-family: inherit;
+	font-size: inherit;
+	-webkit-padding: 0.4em 0;
+	padding: 0.4em;
+	margin: 0 0 0.5em 0;
+	box-sizing: border-box;
+	border: 1px solid #ccc;
+	border-radius: 2px;
+}
+
+input:disabled {
+	color: #ccc;
+}
+
+button {
+	color: #333;
+	background-color: #f4f4f4;
+	outline: none;
+}
+
+button:disabled {
+	color: #999;
+}
+
+button:not(:disabled):active {
+	background-color: #ddd;
+}
+
+button:focus {
+	border-color: #666;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset='utf-8'>
+	<meta name='viewport' content='width=device-width,initial-scale=1'>
+
+	<title>Solbera's Dungeons and Dragons Fifth Edition Fonts</title>
+
+	<link
+	rel="icon"
+	href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📝</text></svg>"
+	/>
+	<link rel='stylesheet' href='/global.css'>
+	<link rel='stylesheet' href='/build/bundle.css'>
+
+	<script defer src='/build/bundle.js'></script>
+</head>
+
+<body>
+</body>
+</html>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,83 @@
+import svelte from 'rollup-plugin-svelte';
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import livereload from 'rollup-plugin-livereload';
+import { terser } from 'rollup-plugin-terser';
+import sveltePreprocess from 'svelte-preprocess';
+import typescript from '@rollup/plugin-typescript';
+import css from 'rollup-plugin-css-only';
+
+const production = !process.env.ROLLUP_WATCH;
+
+function serve() {
+	let server;
+
+	function toExit() {
+		if (server) server.kill(0);
+	}
+
+	return {
+		writeBundle() {
+			if (server) return;
+			server = require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
+				stdio: ['ignore', 'inherit', 'inherit'],
+				shell: true
+			});
+
+			process.on('SIGTERM', toExit);
+			process.on('exit', toExit);
+		}
+	};
+}
+
+export default {
+	input: 'src/main.ts',
+	output: {
+		sourcemap: true,
+		format: 'iife',
+		name: 'app',
+		file: 'public/build/bundle.js'
+	},
+	plugins: [
+		svelte({
+			preprocess: sveltePreprocess({ sourceMap: !production }),
+			compilerOptions: {
+				// enable run-time checks when not in production
+				dev: !production
+			}
+		}),
+		// we'll extract any component CSS out into
+		// a separate file - better for performance
+		css({ output: 'bundle.css' }),
+
+		// If you have external dependencies installed from
+		// npm, you'll most likely need these plugins. In
+		// some cases you'll need additional configuration -
+		// consult the documentation for details:
+		// https://github.com/rollup/plugins/tree/master/packages/commonjs
+		resolve({
+			browser: true,
+			dedupe: ['svelte']
+		}),
+		commonjs(),
+		typescript({
+			sourceMap: !production,
+			inlineSources: !production
+		}),
+
+		// In dev mode, call `npm run start` once
+		// the bundle has been generated
+		!production && serve(),
+
+		// Watch the `public` directory and refresh the
+		// browser on changes when not in production
+		!production && livereload('public'),
+
+		// If we're building for production (npm run build
+		// instead of npm run dev), minify
+		production && terser()
+	],
+	watch: {
+		clearScreen: false
+	}
+};

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+  import Header from "./components/Header.svelte";
+  import { fade, fly } from "svelte/transition";
+  import { baseURL, data, examplePhrases } from "./data";
+  $: showCSS = true;
+  let size = 32;
+  function cssVariables(node, variables) {
+    setCssVariables(node, variables);
+    return {
+      update(variables) {
+        setCssVariables(node, variables);
+      },
+    };
+  }
+  function setCssVariables(node, variables) {
+    for (const name in variables) {
+      node.style.setProperty(`--${name}`, variables[name]);
+    }
+  }
+  export let name: string;
+  function title(str) {
+    return str.replace(/(^|\s)\S/g, function (t) {
+      return t.toUpperCase();
+    });
+  }
+
+  const kebabCase = (string) =>
+    string
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .replace(/[\s_]+/g, "-")
+      .toLowerCase();
+</script>
+
+<svelte:head>
+  <title>Solbera's Dungeons and Dragons Fifth Edition Fonts</title>
+  <meta
+    name="description"
+    content="A dingus to show Solbera's 22 DND 5e font faces, released uncer CC-BY-SA 4.0"
+  />
+</svelte:head>
+
+<!-- <header> -->
+<!-- </header> -->
+<Header bind:size bind:showCSS />
+<p style='padding-top:3em'>
+  This is a copy of Solbera's Creative Commons Attribution Share-Alike 4.0 fonts
+  taken from <a
+    href="https://www.reddit.com/r/UnearthedArcana/comments/3vpphx/5e_font_package_embeddable_cc_edition/"
+    >this Reddit thread</a
+  >, combined with Ryrok's fixes from
+  <a
+    href="https://www.reddit.com/r/UnearthedArcana/comments/4loka0/fixed_versions_of_solberas_fonts/"
+    >this Reddit thread</a
+  >.
+</p>
+<p>The fonts have unique names based on the original fonts' names:</p>
+<table>
+  <thead>
+    <tr>
+      <th>Original Font</th>
+      <th>Solbera's Font</th>
+      <th><a href='http://taxidermicowlbear.weebly.com/dd-fonts.html'>Usage</a></th>
+    </tr>
+  </thead>
+  <tbody>
+    {#each data as font}
+      <tr>
+        <td>{font.originalFont}</td>
+        <td><a href="#{kebabCase(font.family)}">{font.family}</a></td>
+        <td>{font.use}</td>
+      </tr>
+    {/each}
+  </tbody>
+</table>
+<p>
+  This webpage represents the fonts in this GitHub repository as web fonts,
+  using your browser's <a href="https://caniuse.com/#feat=ttf"
+    >OpenType font support</a
+  >.
+</p>
+<div class="container">
+  {#each data as font, i}
+    {@const code = `
+			@font-face {
+				font-family: '${font.family}';
+				src: 
+				local('${font.family}'),
+				local('./${font.family}/${font.family}.otf'),
+				url('${baseURL}${encodeURIComponent(font.family)}/${encodeURIComponent(
+      font.family
+    )}.otf') format('opentype');
+			}`}
+    <p
+      id={kebabCase(font.family)}
+      contenteditable
+      use:cssVariables={{ size }}
+      class="demo"
+      style="font-family: '{font.family}', serif;"
+    >
+      This text is in {font.family}. {examplePhrases[i]}
+    </p>
+    {#if showCSS}
+      <details transition:fade>
+        <summary>CSS code for {font.family}</summary>
+        <pre><code class="css">{code}</code></pre>
+      </details>
+    {/if}
+    {#each Object.entries(font.variants) as [variant, value]}
+      {@const fontName = `${font.family} ${title(variant)}`}
+      {@const code = `
+				@font-face {
+					font-family: '${font.family}';
+					${variant.includes("bold") ? "font-weight: bold;" : ""}
+					${variant.includes("italic") ? "font-style: italic;" : ""}
+					src: 
+					local('${font.family}'),
+					local('./${font.family}/${font.family}.otf'),
+					url('${baseURL}${encodeURIComponent(font.family)}/${encodeURIComponent(
+        fontName
+      )}.otf') format('opentype');
+				}`}
+      {#if value}
+        <p
+          contenteditable
+          use:cssVariables={{ size }}
+          class="demo"
+          style="font-family: '{font.family}', serif; font-weight: {variant.includes(
+            'bold'
+          )
+            ? 'bold'
+            : ''}; font-style: {variant.includes('italic') ? 'italic' : ''};"
+        >
+          This text is in {font.family}
+          {variant}. {examplePhrases[i]}
+        </p>
+        {#if showCSS}
+          <details out:fade in:fly>
+            <summary>CSS code for {font.family}</summary>
+            <pre><code class="css">{code}</code></pre>
+          </details>
+        {/if}
+      {/if}
+    {/each}
+  {/each}
+</div>
+
+<footer>
+  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"
+    ><img
+      alt="Creative Commons License"
+      style="border-width:0"
+      src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"
+    /></a
+  ><br />This work is licensed under a
+  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"
+    >Creative Commons Attribution-ShareAlike 4.0 International License</a
+  >.
+</footer>
+
+<style>
+
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+		width: 100%;
+	}
+	details {
+		overflow-x: auto;
+	}
+
+	.container {
+		padding-top: 3em;
+	}
+
+  .demo {
+    font-size: calc(var(--size) * 1px);
+  }
+
+  footer {
+	padding-top: 3em;
+	text-align: center;
+  }
+
+
+</style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,0 +1,40 @@
+<script lang='ts'>
+    export let size
+    export let showCSS
+    </script>
+<div class='header'>
+    <div class='container'>
+    Solbera's DND 5e Fonts
+    <span class='slider'>font size: {size} <input bind:value={size} type="range" min="12" max="50" /></span>
+    <span class='slider'>Show CSS Code <input bind:checked={showCSS} type="checkbox" /></span>
+    </div>
+</div>
+
+<style>
+    .header {
+        position: fixed;
+        width: 100%;
+        margin: 1;
+        top: 0px;
+        background-color: white;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        .header {
+            background-color: #333;
+		    color: #eee;
+        }
+    }
+
+    .container {
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        padding-left: 0.5rem;
+    }
+
+    input[type='range'] {
+        vertical-align: middle;
+    }
+
+</style>

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,0 +1,121 @@
+interface IFont {
+    originalFont: string
+    family: string
+    use: string
+    variants: {
+        italic: boolean,
+        bold: boolean,
+        'bold italic': boolean
+    }
+}
+
+export const baseURL = 'https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/'
+
+export const data: IFont[] = [
+    {
+        originalFont:'Bookmania',
+        family: 'Bookinsanity',
+        use: 'Body text',
+        variants: {
+            italic: true,
+            bold: true,
+            'bold italic': true
+        }
+    },
+    {
+        originalFont:'Dai Vernon Misdirect',
+        family: 'Zatanna Misdirection',
+        use: 'Monster Manual quotes',
+        variants: {
+            italic: true,
+            bold: true,
+            'bold italic': true
+        }
+    },
+    {
+        originalFont:'Modesto Bold Condensed',
+        family: 'Nodesto Caps Condensed',
+        use: 'Book and card titles',
+        variants: {
+            italic: true,
+            bold: true,
+            'bold italic': true
+        }
+    },
+    {
+        originalFont:'Mrs Eaves Small Caps',
+        family: 'Mr Eaves Small Caps',
+        use: 'Headings',
+        variants: {
+            italic: false,
+            bold: false,
+            'bold italic': false
+        }
+    },
+    {
+        originalFont:'Scala Sans',
+        family: 'Scaly Sans',
+        use: 'Tables',
+        variants: {
+            italic: true,
+            bold: true,
+            'bold italic': true
+        }
+    },
+    {
+        originalFont:'Scala Sans Caps',
+        family: 'Scaly Sans Caps',
+        use: 'Titles of tables',
+        variants: {
+            italic: true,
+            bold: true,
+            'bold italic': true
+        }
+    },
+    {
+        originalFont:'(unknown)',
+        family: 'Solbera Imitation',
+        use: 'Drop caps',
+        variants: {
+            italic: false,
+            bold: false,
+            'bold italic': false
+        }
+    },
+    {
+        originalFont:'(unknown)',
+        family: 'Dungeon Drop Case (Ners)',
+        use: 'Drop caps',
+        variants: {
+            italic: false,
+            bold: false,
+            'bold italic': false
+        }
+    },
+]
+
+export const examplePhrases = [
+    `The wizard Eigengrau shook her head. The text was totally illegible, and she found that she couldn't decipher it, despite her skill.`,
+    `The rains fell softly on the forest, dampening the Ranger as he waited for his prey. The jewels in his pouch clinked gently.`,
+    `The Barbarian waltzed into the bar, sat down at a table, and ordered the largest mug of the foulest brew that the innkeep had to sell. She needed to wash the taste of Undead out of her teeth.`,
+    `The Bard was sure he could get through the gate. All he had to do is convincingly explain why he was being followed by a bright yellow, vocally angry Flumph.`,
+    `The Cleric gave up trying to speak with the Svirfneblin; they had tried Common, Undercommon, Elvish, Gnomish, Goblin, Sylvan, Orc and even Abyssal, but they could not get across to the tiny Svirfneblin the danger it was in.`,
+    `Yesterday the Druid had planted flowers in their garden. Today, they would defend the pumpkin patch against invaders.`,
+    `The Fighter polished her sword. She was stalling for time; this battle would not be pleasant. Sibling rivalries never were.`,
+    `High on the temple tower, the Monk watched the acolytes light the courtyard lanterns below. He was sure he had mastered Slow Fall, but could he prove it to the Abbot?`,
+    `The Paladin had cracked. All they could think was the last words of their opponent: "Only nothingness above."`,
+    `The Rogue was ready. So, so ready. now was the time for dancing, and her competitors would not see her coming.`,
+    `At long last, Luck was with the Sorceror. He had seen what the rest of the party had not, and quickly cast Snilloc's Snowball Storm to defend against the schoolchildren.`,
+    `The Warlock's patron had brought 'em to a strange and desolate island, but their task here was obvious. The castle on the central peak must be purged.`,
+    `The Wizard was running late. She'd missed the last ferry to the city, and though she had been able to procure a kayak, her lack of proficiency with it was rapidly drawing her towards the city's waterfall.`,
+    `In a hole in the ground there lived a Halfling, for he had not yet heard the call of adventure. That would come next week, when the tavern burned down.`,
+    `The dragon was discontent, for its entire horde had disappeared while it was out hunting. It suspected the local fishermen, and set out to steal their boats.`,
+    `It was a time of peace, and so of course the Soldier was worried. The silence of the night kept her waiting for the zip of an arrow, the crackle of a spell, the scream of a sword. She needed something to do, and that would probably require desertion.`,
+    `Why was the Criminal in this city? Certainly he didn't need any money. But the pact he had made with his patron required him to seek knowledge, and this town's university had a tempting library.`,
+    `If one more traveling writer asked the Hermit what life was like atop her pole, she swore she would climb down, uproot her pole, drag it into the city where the writers came from, and spit their leader upon its sharpened point.`,
+    `This Urchin had grown up on the streets alone, until this Urchin forged a family. Now, these Urchins ruled seven city blocks. Soon, they would be big enough to take on the City Guard.`,
+    `The Charlatan was bored, bored, bored. He'd been stuck on this rock for seventeen days after being thrown overboard by the pirates. Was that a sail on the horizon? No, probably just a wisp of cloud.`,
+    `The Sailor didn't expect to find a tiefling sitting on a rock in the middle of an ocean, and she didn't expect him to be such a smooth talker. If he deserted her when they hit port, she'd kill him herself.`,
+    `The Weapon Master was also a blacksmith, which was helpful when a roving party came to town, flush with money, looking for upgraded blades. They wanted swords? She had swords. Lots of swords.`,
+    `If you can read this text, talk to the priest of the smallest temple in the city.`,
+]

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="svelte" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,10 @@
+import App from './App.svelte';
+
+const app = new App({
+	target: document.body,
+	props: {
+		name: 'world'
+	}
+});
+
+export default app;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,130 @@
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Bookinsanity";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Zatanna Misdirection";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Nodesto Caps Condensed";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Mr Eaves Small Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Scaly Sans";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+    font-weight: bold;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: "Scaly Sans Caps";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
+    font-weight: normal;
+    font-style: italic;
+}
+@font-face {
+    font-family: "Solbera Imitation";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Solbera Imitation/Solbera Imitation.otf") format("opentype");
+    font-weight: normal;
+}
+@font-face {
+    font-family: "Dungeon Drop Case";
+    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
+    font-weight: normal;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,130 +1,189 @@
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity.otf") format("opentype");
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold Italic.otf") format("opentype");
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Bold.otf") format("opentype");
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Bookinsanity";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Bookinsanity/Bookinsanity Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Bookinsanity Remake"),
+        local("Bookinsanity"),
+        url('./Bookinsanity/Bookinsanity Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Bookinsanity/Bookinsanity%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection.otf") format("opentype");
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf") format("opentype");
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Bold.otf") format("opentype");
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Zatanna Misdirection";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Zatanna Misdirection/Zatanna Misdirection Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Zatanna Misdirection Remake"),    
+        local("Zatanna Misdirection"),
+        url('./Zatanna Misdirection/Zatanna Misdirection Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Zatanna%20Misdirection/Zatanna%20Misdirection%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed.otf") format("opentype");
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf") format("opentype");
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf") format("opentype");
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Nodesto Caps Condensed";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Nodesto Caps Condensed"),
+        url('./Nodesto Caps Condensed/Nodesto Caps Condensed Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Nodesto%20Caps%20Condensed/Nodesto%20Caps%20Condensed%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Mr Eaves Small Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Mr Eaves/Mr Eaves Small Caps.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Mr Eaves Small Caps"),
+        url('./Mr Eaves/Mr Eaves Small Caps.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Mr%20Eaves/Mr%20Eaves%20Small%20Caps.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold Italic.otf") format("opentype");
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Bold.otf") format("opentype");
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Scaly Sans";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans/Scaly Sans Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans"),
+        url('./Scaly Sans/Scaly Sans Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans/Scaly%20Sans%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps.otf") format("opentype");
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf") format("opentype");
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Bold Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold%20Italic.otf") format("opentype");
     font-weight: bold;
     font-style: italic;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Bold.otf") format("opentype");
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Bold.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Bold.otf") format("opentype");
     font-weight: bold;
-    font-style: normal;
 }
 @font-face {
     font-family: "Scaly Sans Caps";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Scaly Sans Caps/Scaly Sans Caps Italic.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Scaly Sans Caps"),
+        url('./Scaly Sans Caps/Scaly Sans Caps Italic.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Scaly%20Sans%20Caps/Scaly%20Sans%20Caps%20Italic.otf") format("opentype");
     font-style: italic;
 }
 @font-face {
     font-family: "Solbera Imitation";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Solbera Imitation/Solbera Imitation.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Solbera Imitation"),
+        url('./Solbera Imitation/Solbera Imitation.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Solbera%20Imitation/Solbera%20Imitation.otf") format("opentype");
 }
 @font-face {
     font-family: "Dungeon Drop Case";
-    src: url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/blob/master/Dungeon Drop Case/Dungeon Drop Case.otf") format("opentype");
-    font-weight: normal;
+    src: 
+        local("Dungeon Drop Case"),
+        url('/Dungeon Drop Case/Dungeon Drop Case.otf'),
+        url("https://raw.githubusercontent.com/jonathonf/solbera-dnd-fonts/master/Dungeon%20Drop%20Case/Dungeon%20Drop%20Case.otf") format("opentype");
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
+}


### PR DESCRIPTION
I have updated the html to use Svelte, which should allow for easy extension in future.

Features:
* Now uses Svelte with no other dependencies for a minimal footprint
* Prefer-dark-mode
* Reactive resizing of the font
* Hideable CSS code
* Smaller code footprint
* Emoji favicon
* Sticky header